### PR TITLE
Format code blocks in database-testing.md 

### DIFF
--- a/database-testing.md
+++ b/database-testing.md
@@ -99,70 +99,72 @@ Laravelは、データベース駆動のアプリケーションを簡単にテ�
 機能テスト中に[データベースシーダー](seeding.md)を使用してデータベースをデータで埋めたい場合は、`seed`メソッドを呼び出すことができます。デフォルトでは、`seed`メソッドは`DatabaseSeeder`を実行し、これにより他のすべてのシーダーが実行されます。または、特定のシーダークラス名を`seed`メソッドに渡すこともできます：
 
 ===  "Pest"
-```php
-<?php
 
-use Database\Seeders\OrderStatusSeeder;
-use Database\Seeders\TransactionStatusSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-
-uses(RefreshDatabase::class);
-
-test('orders can be created', function () {
-    // DatabaseSeederを実行...
-    $this->seed();
-
-    // 特定のシーダーを実行...
-    $this->seed(OrderStatusSeeder::class);
-
-    // ...
-
-    // 特定のシーダーの配列を実行...
-    $this->seed([
-        OrderStatusSeeder::class,
-        TransactionStatusSeeder::class,
-        // ...
-    ]);
-});
-```
-
-===  "PHPUnit"
-```php
-<?php
-
-namespace Tests\Feature;
-
-use Database\Seeders\OrderStatusSeeder;
-use Database\Seeders\TransactionStatusSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
-class ExampleTest extends TestCase
-{
-    use RefreshDatabase;
-
-    /**
-     * 新しい注文の作成テスト。
-     */
-    public function test_orders_can_be_created(): void
-    {
+    ```php
+    <?php
+    
+    use Database\Seeders\OrderStatusSeeder;
+    use Database\Seeders\TransactionStatusSeeder;
+    use Illuminate\Foundation\Testing\RefreshDatabase;
+    
+    uses(RefreshDatabase::class);
+    
+    test('orders can be created', function () {
         // DatabaseSeederを実行...
         $this->seed();
-
+    
         // 特定のシーダーを実行...
         $this->seed(OrderStatusSeeder::class);
-
+    
         // ...
-
+    
         // 特定のシーダーの配列を実行...
         $this->seed([
             OrderStatusSeeder::class,
             TransactionStatusSeeder::class,
             // ...
         ]);
+    });
+    ```
+
+===  "PHPUnit"
+
+    ```php
+    <?php
+    
+    namespace Tests\Feature;
+    
+    use Database\Seeders\OrderStatusSeeder;
+    use Database\Seeders\TransactionStatusSeeder;
+    use Illuminate\Foundation\Testing\RefreshDatabase;
+    use Tests\TestCase;
+    
+    class ExampleTest extends TestCase
+    {
+        use RefreshDatabase;
+    
+        /**
+         * 新しい注文の作成テスト。
+         */
+        public function test_orders_can_be_created(): void
+        {
+            // DatabaseSeederを実行...
+            $this->seed();
+    
+            // 特定のシーダーを実行...
+            $this->seed(OrderStatusSeeder::class);
+    
+            // ...
+    
+            // 特定のシーダーの配列を実行...
+            $this->seed([
+                OrderStatusSeeder::class,
+                TransactionStatusSeeder::class,
+                // ...
+            ]);
+        }
     }
-}
-```
+    ```
 
 または、`RefreshDatabase`トレイトを使用する各テストの前に、Laravelにデータベースを自動的にシードするように指示できます。これは、ベーステストクラスに`$seed`プロパティを定義することで実現できます：
 

--- a/database-testing.md
+++ b/database-testing.md
@@ -17,44 +17,45 @@ Laravelは、データベース駆動のアプリケーションを簡単にテ�
 さらに進む前に、各テスト後にデータベースをリセットする方法について説明しましょう。これにより、前のテストのデータが後続のテストに干渉しないようになります。Laravelに含まれる`Illuminate\Foundation\Testing\RefreshDatabase`トレイトが、これを処理します。テストクラスでトレイトを使用するだけです：
 
 ===  "Pest"
-```php
-<?php
-
-use Illuminate\Foundation\Testing\RefreshDatabase;
-
-uses(RefreshDatabase::class);
-
-test('basic example', function () {
-    $response = $this->get('/');
-
-    // ...
-});
-```
+    ```php
+    <?php
+    
+    use Illuminate\Foundation\Testing\RefreshDatabase;
+    
+    uses(RefreshDatabase::class);
+    
+    test('basic example', function () {
+        $response = $this->get('/');
+    
+        // ...
+    });
+    ```
 
 ===  "PHPUnit"
-```php
-<?php
 
-namespace Tests\Feature;
-
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
-
-class ExampleTest extends TestCase
-{
-    use RefreshDatabase;
-
-    /**
-     * 基本的な機能テストの例。
-     */
-    public function test_basic_example(): void
+    ```php
+    <?php
+    
+    namespace Tests\Feature;
+    
+    use Illuminate\Foundation\Testing\RefreshDatabase;
+    use Tests\TestCase;
+    
+    class ExampleTest extends TestCase
     {
-        $response = $this->get('/');
-
-        // ...
+        use RefreshDatabase;
+    
+        /**
+         * 基本的な機能テストの例。
+         */
+        public function test_basic_example(): void
+        {
+            $response = $this->get('/');
+    
+            // ...
+        }
     }
-}
-```
+    ```
 
 `Illuminate\Foundation\Testing\RefreshDatabase`トレイトは、スキーマが最新の場合、データベースをマイグレートしません。代わりに、データベーストランザクション内でテストを実行するだけです。したがって、このトレイトを使用しないテストケースによってデータベースに追加されたレコードは、データベースに残る可能性があります。
 
@@ -68,27 +69,29 @@ class ExampleTest extends TestCase
 モデルファクトリの作成と使用方法について詳しくは、完全な[モデルファクトリのドキュメント](eloquent-factories.md)を参照してください。モデルファクトリを定義したら、テスト内でファクトリを使用してモデルを作成できます：
 
 ===  "Pest"
-```php
-use App\Models\User;
 
-test('models can be instantiated', function () {
-    $user = User::factory()->create();
-
-    // ...
-});
-```
+    ```php
+    use App\Models\User;
+    
+    test('models can be instantiated', function () {
+        $user = User::factory()->create();
+    
+        // ...
+    });
+    ```
 
 ===  "PHPUnit"
-```php
-use App\Models\User;
 
-public function test_models_can_be_instantiated(): void
-{
-    $user = User::factory()->create();
-
-    // ...
-}
-```
+    ```php
+    use App\Models\User;
+    
+    public function test_models_can_be_instantiated(): void
+    {
+        $user = User::factory()->create();
+    
+        // ...
+    }
+    ```
 
 <a name="running-seeders"></a>
 ## シーダーの実行


### PR DESCRIPTION
Standardized the indentation and formatting of the code blocks in the Pest and PHPUnit sections for better readability and consistency. This change improves the presentation and ensures uniformity across the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved formatting and structure of the `database-testing.md` file for enhanced readability.
	- Reformatted code examples for Pest and PHPUnit with better alignment and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->